### PR TITLE
Ensuring that models work client-side

### DIFF
--- a/app/models/passport.js
+++ b/app/models/passport.js
@@ -7,5 +7,5 @@ var Passport = function () {
   this.belongsTo('User');
 };
 
-exports.Passport = Passport;
+Passport = geddy.model.register('Passport', Passport);
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -14,5 +14,4 @@ var User = function () {
   this.hasMany('Passports');
 };
 
-exports.User = User;
-
+User = geddy.model.register('User', User);


### PR DESCRIPTION
Browser throws error because `exports` isn't defined.
Changed `exports` to `geddy.model.register`.
Fixes mde/geddy#467.
