### PR TITLE
Fixed references to _form partial

### DIFF
--- a/app/views_handlebars/users/add.html.hbs
+++ b/app/views_handlebars/users/add.html.hbs
@@ -11,7 +11,7 @@
           </ul>
         </div>
       {{/if}}
-      {{{ partial '_form' user=params }}}
+      {{{ partial 'form' user=params }}}
       <div class="form-actions">
         {{{ contentTag 'input' 'Add' type='submit' class='btn btn-primary' }}}
       </div>

--- a/app/views_handlebars/users/edit.html.hbs
+++ b/app/views_handlebars/users/edit.html.hbs
@@ -11,7 +11,7 @@
           </ul>
         </div>
       {{/if}}
-      {{{ partial '_form' user=user }}}
+      {{{ partial 'form' user=user }}}
       <div class="form-actions">
         {{{ contentTag 'input' 'Save' type='submit' class='btn btn-primary' }}}
         <button type="submit" formaction="{{{ userPath params.id }}}?_method=DELETE" formmethod='POST' class='btn btn-danger'>Remove</button>

--- a/app/views_jade/users/add.html.jade
+++ b/app/views_jade/users/add.html.jade
@@ -7,6 +7,6 @@
           ul
             each err in params.errors
               li=err
-      = partial('_form', {user: params});
+      = partial('form', {user: params});
       .form-actions
         != contentTag('input', 'Add', {type: 'submit', class: 'btn btn-primary'})

--- a/app/views_jade/users/edit.html.jade
+++ b/app/views_jade/users/edit.html.jade
@@ -7,7 +7,7 @@
           ul
             each err in params.errors
               li=err
-      = partial('_form', {user: user});
+      = partial('form', {user: user});
       .form-actions
         != contentTag('input', 'Save', {type: 'submit', class: 'btn btn-primary'})
         != contentTag('button', 'Remove', {type: 'submit', formaction: userPath(params.id) + '?_method=DELETE', formmethod: 'POST', class: 'btn btn-danger'})

--- a/app/views_mustache/users/add.html.ms
+++ b/app/views_mustache/users/add.html.ms
@@ -11,7 +11,7 @@
           </ul>
         </div>
       {{/if}}
-      {{{ partial '_form' user=params }}}
+      {{{ partial 'form' user=params }}}
       <div class="form-actions">
         {{{ contentTag 'input' 'Add' type='submit' class='btn btn-primary' }}}
       </div>

--- a/app/views_mustache/users/edit.html.ms
+++ b/app/views_mustache/users/edit.html.ms
@@ -11,7 +11,7 @@
           </ul>
         </div>
       {{/if}}
-      {{{ partial '_form' user=user }}}
+      {{{ partial 'form' user=user }}}
       <div class="form-actions">
         {{{ contentTag 'input' 'Save' type='submit' class='btn btn-primary' }}}
         <button type="submit" formaction="{{{ userPath params.id }}}?_method=DELETE" formmethod='POST' class='btn btn-danger'>Remove</button>

--- a/app/views_swig/users/add.html.swig
+++ b/app/views_swig/users/add.html.swig
@@ -11,7 +11,7 @@
         </ul>
       </div>
       {% endif %}
-      {% set formPath = [process.cwd(), 'app/views/users/_form.html.swig'] %}
+      {% set formPath = [process.cwd(), 'app/views/users/form.html.swig'] %}
       {% set formPath = formPath|join('/') %}
       {% include formPath %}
       <div class="form-actions">

--- a/app/views_swig/users/edit.html.swig
+++ b/app/views_swig/users/edit.html.swig
@@ -11,7 +11,7 @@
         </ul>
       </div>
       {% endif %}
-      {% set formPath = [process.cwd(), 'app/views/users/_form.html.swig'] %}
+      {% set formPath = [process.cwd(), 'app/views/users/form.html.swig'] %}
       {% set formPath = formPath|join('/') %}
       {% include formPath with user %}
       <div class="form-actions">


### PR DESCRIPTION
Apparently there was a commit a while ago which removed underscores from partials (8b98f568dea53f895e8a0f3c0a96d7cd2b7cda66) but missed the references to them.

Fixes #21, #22
Partial fix for #23